### PR TITLE
fix(agent): ensure that we install Zabbix 7.0 LTS

### DIFF
--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -6,6 +6,7 @@ radiorabe_zabbix_agent_generate_cert: true
 
 _radiorabe_zabbix_agent_package_name: zabbix-agent2
 _radiorabe_zabbix_agent_package_state: present
+_radiorabe_zabbix_agent_version: "7"
 
 _radiorabe_zabbix_agent_certificate_rolename: redhat.rhel_system_roles.certificate
 _radiorabe_zabbix_agent_firewall_rolename: redhat.rhel_system_roles.firewall

--- a/roles/agent/tasks/main.yaml
+++ b/roles/agent/tasks/main.yaml
@@ -37,6 +37,7 @@
     zabbix_install_pip_packages: false
     zabbix_agent_disable_repo: []
     zabbix_agent_install_agent_only: true
+    zabbix_agent_version: "{{ _radiorabe_zabbix_agent_version }}"
     # config
     zabbix_agent_dont_detect_ip: true
     zabbix_agent_allowkeys: "{{ (__radiorabe_zabbix_agent_allow_key + radiorabe_zabbix_agent_extra_allow_key) | unique }}"
@@ -67,6 +68,7 @@
     zabbix_install_pip_packages: false
     zabbix_agent_disable_repo: []
     zabbix_agent_install_agent_only: true
+    zabbix_agent_version: "{{ _radiorabe_zabbix_agent_version }}"
     # config
     zabbix_agent_dont_detect_ip: true
     zabbix_agent_allowkeys: "{{ (__radiorabe_zabbix_agent_allow_key + radiorabe_zabbix_agent_extra_allow_key) | unique }}"


### PR DESCRIPTION
I noticed that `vm-0038.service.int.rabe.ch` doesn't exhibit the issues with trying to install a non LTS version of Zabbix.

I has `zabbix_agent_version` at the host level, overriding it in `radiorabe.zabbix.agent` directly will most likely ensure that the role doesn't try to install an updated package.

* fixes #52 